### PR TITLE
Windows: fix warnings about casting pointer to int of a different size

### DIFF
--- a/xa/src/xap.c
+++ b/xa/src/xap.c
@@ -792,7 +792,7 @@ int pp_open(char *name)
      flist[0].filep=fp;
      flist[0].flinep=NULL;    
 
-     return(((long)fp)==0l);
+     return fp == NULL;
 }
 
 void pp_close(void)

--- a/xa/src/xap.c
+++ b/xa/src/xap.c
@@ -595,7 +595,7 @@ int pp_replace(char *to, char *ti, int a,int b)
                                         if(!er)
                                              er=pp_replace(fto,fti,rlist,rlist+i);
 /*               if(flag) printf("sl=%d,",sl);*/
-                                        sl=(int)((long)y+1L-(long)t);
+                                        sl=(int)(y +1 - t);
 /*               if(flag) printf("sl=%d\n",sl);*/
                                         rs=fto;
 /*     printf("->%s\n",fto);*/
@@ -706,7 +706,7 @@ int pp_replace(char *to, char *ti, int a,int b)
                                         }   
                                         if(!er)
                                              er=pp_replace(fto,fti,0,rlist+i);
-                                        sl=(int)((long)y+1L-(long)t);
+                                        sl=(int)(y + 1 - t);
                                         rs=fto;
                                    }    
                               }


### PR DESCRIPTION
On Windows x64, long is 32-bit, while a pointer is 64-bit (on Linux both
long and pointers are 64-bit), this removes the useless casts triggering
the warnings.